### PR TITLE
Large corrections on Tools/Sigwhatever/README.md file.

### DIFF
--- a/Tools/Sigwhatever/README.md
+++ b/Tools/Sigwhatever/README.md
@@ -46,33 +46,33 @@ Bear in mind that even running jobkill on the .net job does not seem to kill the
 
 ### OPERATIONS:
 
-- AUTO: Just do everything for me - backdoor the signature and start the listener on this box.    
-  Usage: `SigWhatever.exe AUTO`
+- **AUTO**: Just do everything for me - backdoor the signature and start the listener on this box.    
+  _Usage_: `SigWhatever.exe AUTO`
 
-- CHECKTRUST: Check whether the trust zone settings - if the domain isn't in there then this probably won't work.    
-  Usage: `SigWhatever.exe CHECKTRUST`
+- **CHECKTRUST**: Check whether the trust zone settings - if the domain isn't in there then this probably won't work.    
+  _Usage_: `SigWhatever.exe CHECKTRUST`
 
-- CHECKFW: Check whether the host based firewall is on and whether there's an exception for the chosen port.    
-  Usage: `SigWhatever.exe CHECKFW -p <port>`
+- **CHECKFW**: Check whether the host based firewall is on and whether there's an exception for the chosen port.    
+  _Usage_: `SigWhatever.exe CHECKFW -p <port>`
   
--  SIGNATURE: hijack the current user's signature, or add a new one via registry changes.    
-  Usage: `SigWhatever.exe SIGNATURE -p <port> -l <logfile> -u <url prefix> --backdoor-all --force`    
-  Note: With the signature option, if --backdoor-all is not specified then the tool will attempt to get the current signature from Outlook - this may cause a popup for the user if their AV is out of date.
+-  **SIGNATURE**: hijack the current user's signature, or add a new one via registry changes.    
+  _Usage_: `SigWhatever.exe SIGNATURE -p <port> -l <logfile> -u <url prefix> --backdoor-all --force`    
+  _Note_: With the signature option, if --backdoor-all is not specified then the tool will attempt to get the current signature from Outlook - this may cause a popup for the user if their AV is out of date.
 
-- SIGNOLISTEN: hijack the current user's signature, or add a new one via registry changes.    
-  Usage: `SigWhatever.exe SIGNOLISTEN -s <server> -p <port> -l <logfile> --backdoor-all>`
+- **SIGNOLISTEN**: hijack the current user's signature, or add a new one via registry changes.    
+  _Usage_: `SigWhatever.exe SIGNOLISTEN -s <server> -p <port> -l <logfile> --backdoor-all>`
 
-- CLEANUP: Remove any modifications to the registry or htm signature files.    
-  Usage: `SigWhatever.exe CLEANUP`
+- **CLEANUP**: Remove any modifications to the registry or htm signature files.    
+  _Usage_: `SigWhatever.exe CLEANUP`
 
-- EMAILADMINS: Enumerate email addresses from an AD group and send them a 'blank' email with the payload.    
-  Usage: `SigWhatever.exe EMAILADMINS -g <Active Directory group> -p <port> -l <logfile> --force`
+- **EMAILADMINS**: Enumerate email addresses from an AD group and send them a 'blank' email with the payload.    
+  _Usage_: `SigWhatever.exe EMAILADMINS -g <Active Directory group> -p <port> -l <logfile> --force`
 
-- LISTENONLY: Just start the listener - make sure it's on the same port.    
-  Usage: `SigWhatever.exe LISTENONLY -p <port> -l <logfile>`
+- **LISTENONLY**: Just start the listener - make sure it's on the same port.    
+  _Usage_: `SigWhatever.exe LISTENONLY -p <port> -l <logfile>`
 
-- SHOWACLS: List all URL Reservation ACLs with User, Everyone or Authenticated Users permissions.    
-  Usage: `SigWhatever.exe SHOWACLS`
+- **SHOWACLS**: List all URL Reservation ACLs with User, Everyone or Authenticated Users permissions.    
+  _Usage_: `SigWhatever.exe SHOWACLS`
 
   
 ## Authors: 

--- a/Tools/Sigwhatever/README.md
+++ b/Tools/Sigwhatever/README.md
@@ -55,11 +55,11 @@ Bear in mind that even running jobkill on the .net job does not seem to kill the
 - **CHECKFW**: Check whether the host based firewall is on and whether there's an exception for the chosen port.    
   _Usage_: `SigWhatever.exe CHECKFW -p <port>`
   
--  **SIGNATURE**: hijack the current user's signature, or add a new one via registry changes.    
+-  **SIGNATURE**: Hijack the current user's signature, or add a new one via registry changes.    
   _Usage_: `SigWhatever.exe SIGNATURE -p <port> -l <logfile> -u <url prefix> --backdoor-all --force`    
-  _Note_: With the signature option, if --backdoor-all is not specified then the tool will attempt to get the current signature from Outlook - this may cause a popup for the user if their AV is out of date.
+  _Note_: If `--backdoor-all` is not specified then the tool will attempt to get the current signature from Outlook - this may cause a popup for the user if their AV is outdated.
 
-- **SIGNOLISTEN**: hijack the current user's signature, or add a new one via registry changes.    
+- **SIGNOLISTEN**: Hijack the current user's signature, or add a new one via registry changes.    
   _Usage_: `SigWhatever.exe SIGNOLISTEN -s <server> -p <port> -l <logfile> --backdoor-all>`
 
 - **CLEANUP**: Remove any modifications to the registry or htm signature files.    

--- a/Tools/Sigwhatever/README.md
+++ b/Tools/Sigwhatever/README.md
@@ -1,4 +1,4 @@
-Sigwhatever
+# Sigwhatever
 For automated exploitation of netntlm hash capture via image tags in emails signatures. This targets Outlook specifically and will insert a 1x1px image into an existing signature block, or create a new signature as required. A listener is then started to capture authentication attempts that happen as a result of sent emails being viewed by other users.
 
 The tool borrows code from the Seatbelt and Inveigh projects - features are:
@@ -12,27 +12,28 @@ The tool borrows code from the Seatbelt and Inveigh projects - features are:
 * Option to create encrypted logs on disk
 * Cleanup (Reverts changes in signature settings and existing signature)
 
-==========
+---
 
-**TL DR:**
+## TL;DR
 
 run:
 
-**execute-assembly sigwhatever.exe AUTO**
+`execute-assembly sigwhatever.exe AUTO`
 
 Then when you're finished, run:
 
-**execute-assembly sigwhatever.exe CLEANUP**
+`execute-assembly sigwhatever.exe CLEANUP`
 
 Bear in mind that even running jobkill on the .net job does not seem to kill the spawned process.
 
-==========
+---
+## Usage
+
+`SigWhatever.exe [OPTIONS]+ operation`
 
 
-Usage: SigWhatever.exe [OPTIONS]+ operation
-
-
-Options:
+### OPTIONS:
+```
   -p, --port=VALUE           TCP Port.
   -l, --log=VALUE            Log file path.
   -g, --group=VALUE          Target Active Directory group.
@@ -41,35 +42,40 @@ Options:
   -c, --challenge=VALUE      NTLM Challenge (in hex).
   -u, --url-prefix=VALUE     URL Prefix. e.g. /MDEServer/test
   -h, --help                 Show this message and exit.
+```
 
-Operations:
-  AUTO: Just do everything for me - backdoor the signature and start the listener on this box.
-  Usage: SigWhatever.exe AUTO
+### OPERATIONS:
 
-  CHECKTRUST: Check whether the trust zone settings - if the domain isn't in there then this probably won't work
-  Usage: SigWhatever.exe CHECKTRUST
+- AUTO: Just do everything for me - backdoor the signature and start the listener on this box.    
+  Usage: `SigWhatever.exe AUTO`
 
-  CHECKFW: Check whether the host based firewall is on and whether there's an exception for the chosen port
-  Usage: SigWhatever.exe CHECKFW -p <port>
+- CHECKTRUST: Check whether the trust zone settings - if the domain isn't in there then this probably won't work.    
+  Usage: `SigWhatever.exe CHECKTRUST`
 
-  SIGNATURE: hijack the current user's signature, or add a new one via registry changes
-  Usage: SigWhatever.exe SIGNATURE -p <port> -l <logfile> -u <url prefix> --backdoor-all --force
-
-  SIGNOLISTEN: hijack the current user's signature, or add a new one via registry changes
-  Usage: SigWhatever.exe SIGNOLISTEN -s <server> -p <port> -l <logfile> --backdoor-all>
-
-  CLEANUP: Remove any modifications to the registry or htm signature files
-  Usage: SigWhatever.exe CLEANUP
-
-  EMAILADMINS: Enumerate email addresses from an AD group and send them a 'blank' email with the payload.
-  Usage: SigWhatever.exe EMAILADMINS -g <Active Directory group> -p <port> -l <logfile> --force
-
-  LISTENONLY: Just start the listener - make sure it's on the same port
-  Usage: SigWhatever.exe LISTENONLY -p <port> -l <logfile>
-
-  SHOWACLS: List all URL Reservation ACLs with User, Everyone or Authenticated Users permissions.
-  Usage: SigWhatever.exe SHOWACLS
-
-  NOTE: With the signature option, if --backdoor-all is not specified then the tool will attempt to get the current signature from Outlook - this may cause a popup for the user if their AV is out of date.
+- CHECKFW: Check whether the host based firewall is on and whether there's an exception for the chosen port.    
+  Usage: `SigWhatever.exe CHECKFW -p <port>`
   
-Authors: David Cash, Rich Warren, Julian Storr 
+-  SIGNATURE: hijack the current user's signature, or add a new one via registry changes.    
+  Usage: `SigWhatever.exe SIGNATURE -p <port> -l <logfile> -u <url prefix> --backdoor-all --force`    
+  Note: With the signature option, if --backdoor-all is not specified then the tool will attempt to get the current signature from Outlook - this may cause a popup for the user if their AV is out of date.
+
+- SIGNOLISTEN: hijack the current user's signature, or add a new one via registry changes.    
+  Usage: `SigWhatever.exe SIGNOLISTEN -s <server> -p <port> -l <logfile> --backdoor-all>`
+
+- CLEANUP: Remove any modifications to the registry or htm signature files.    
+  Usage: `SigWhatever.exe CLEANUP`
+
+- EMAILADMINS: Enumerate email addresses from an AD group and send them a 'blank' email with the payload.    
+  Usage: `SigWhatever.exe EMAILADMINS -g <Active Directory group> -p <port> -l <logfile> --force`
+
+- LISTENONLY: Just start the listener - make sure it's on the same port.    
+  Usage: `SigWhatever.exe LISTENONLY -p <port> -l <logfile>`
+
+- SHOWACLS: List all URL Reservation ACLs with User, Everyone or Authenticated Users permissions.    
+  Usage: `SigWhatever.exe SHOWACLS`
+
+  
+## Authors: 
+- David Cash
+- Rich Warren
+- Julian Storr 


### PR DESCRIPTION
- Added codeblocks.
- Made the "operations" section an unordered list.
- Replaced "======" with the correct separators.
- Made "Authors" section prettier.
- Added dots at the end of some sentences that needed them.
- Prettyfied "Operations" section